### PR TITLE
Add support for syncthing-macos app install

### DIFF
--- a/src/data/syncthing_local_datasource.ts
+++ b/src/data/syncthing_local_datasource.ts
@@ -77,6 +77,19 @@ export class SyncthingFromCLI {
 		}
 		// eslint-disable-next-line @typescript-eslint/no-var-requires
 		const { promisify } = require("util");
+		// MacOS - try the syncthing-macos application package first, 
+		// otherwise we'll fall back to the regular path traversal search
+		if (Platform.isMacOS && command.startsWith("syncthing")) {
+			// application folder for syncthing-macos install
+			const APP_REF = "/Applications/Syncthing.app/Contents/Resources/syncthing/";
+			// eslint-disable-next-line @typescript-eslint/no-var-requires
+			const { stat } = require("fs");
+			const statPromise = promisify(stat);
+			const stats = await statPromise(APP_REF);
+			if (stats.isDirectory()) {
+				command = APP_REF + command;
+			}
+		}
 		// eslint-disable-next-line @typescript-eslint/no-var-requires
 		const { exec } = require("child_process");
 		const execPromise = promisify(exec);


### PR DESCRIPTION
As per issue #166 , add in detection of cli on MacOS when using the syncthing-macos package (eg. `brew install --cask syncthing` ).

This package doesn't add the syncthing cli into the path.  Instead it lives hidden under the application package.

When this package is not installed on MacOS, then it falls back to the previous/regular path lookup.